### PR TITLE
Use Opscode Omnibus installer for Chef

### DIFF
--- a/scripts/chef/debian.sh
+++ b/scripts/chef/debian.sh
@@ -1,20 +1,5 @@
-# cargo culted from OpsCode's guide at http://wiki.opscode.com/display/chef/Installing+Chef+Client+on+Ubuntu+or+Debian
-# skip if the keys are present
+# skip if chef-solo is present
 if (which chef-solo); then exit 0; fi
 
-# install the basics
-apt-get install -y wget lsb-release;
-
-# add the opscode repo to the sources
-echo "deb http://apt.opscode.com/ `lsb_release -cs`-0.10 main" | sudo tee /etc/apt/sources.list.d/opscode.list;
-
-# setup the gpg key
-mkdir -p /etc/apt/trusted.gpg.d;
-gpg --keyserver keys.gnupg.net --recv-keys 83EF826A;
-gpg --export packages@opscode.com | sudo tee /etc/apt/trusted.gpg.d/opscode-keyring.gpg > /dev/null;
-
-# update the repo to make sure that the package is available from the repo
-apt-get update;
-
-# avoid server url popup
-echo "chef chef/chef_server_url string https://api.opscode.com/organizations/vagrant" | debconf-set-selections && apt-get install chef -y;
+# download and run the omnibus installer
+wget -O - http://www.opscode.com/chef/install.sh | bash

--- a/scripts/chef/redhat.sh
+++ b/scripts/chef/redhat.sh
@@ -1,21 +1,5 @@
-# cargo culted from OpsCode's guide at http://wiki.opscode.com/display/chef/Installing+Chef+Client+on+CentOS
 # skip if chef-solo is present
 if (which chef-solo); then exit 0; fi
 
-# add the repo for ruby and other deps
-rpm -Uvh http://rbel.frameos.org/rbel6
-
-# install the pre-reqs
-yum install -y ruby ruby-devel ruby-ri ruby-rdoc ruby-shadow gcc gcc-c++ automake autoconf make curl dmidecode
-
-# install rubygems
-if ! (which gem); then
-  cd /tmp
-  curl -O http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz
-  tar zxf rubygems-1.8.10.tgz
-  cd rubygems-1.8.10
-  ruby setup.rb --no-format-executable
-fi
-
-# install chef via rubygems
-gem install chef --no-ri --no-rdoc
+# download and run the omnibus installer
+wget -O - http://www.opscode.com/chef/install.sh | bash


### PR DESCRIPTION
All official Digital Ocean images should be supported by the [omnibus installer](http://www.opscode.com/chef/install/).

At least Debian might not have curl in the base image, so use wget for all.

**Note**: Because of #10 I was not able to test it via the plugin yet, but I tried manual install on various different images.
