### PR TITLE
Update README to reflect ca_path config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ Vagrant.configure("2") do |config|
     vm.image = "Ubuntu 12.04 x32 Server"
     vm.region = "New York 1"
     vm.size = "512MB"
+    vm.ca_path = "/usr/local/etc/openssl/ca-bundle.crt" # optional config for SSL cert on OSX and others
   end
 end
 ```
 
-Note that the example contains the default value. The client identifier and API key are pulled from the environment and the other values are the string representations of the droplet configuration options as provided by the [Digital Ocean API](https://www.digitalocean.com/api).
+Note that the example contains the default value. The client identifier and API key are pulled from the environment and the other values are the string representations of the droplet configuration options as provided by the [Digital Ocean API](https://www.digitalocean.com/api). The ca_path configuration option may be necessary depending on your system setup.
 
 ## Contributing
 


### PR DESCRIPTION
Add ca_path to the config example, along with a brief explanation of why it's there.
