### PR TITLE
refactored ssh key support into its own middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,20 @@
 
 `vagrant-digitalocean` is a provider plugin for Vagrant that allows the management of [Digital Ocean](https://www.digitalocean.com/) droplets (instances).
 
-## SSH Key Support
+## SSH Keys
 
-By default the provider will use the *insecure* vagrant key for SSH access. That means anyone with the vagrant key and the IP of your droplet has root on your machine. To ovvrride this behavior, define your SSH key name and public key path within the provider configuration:
+This provider does not support the use of Vagrant's insecure key for SSH access. You must specify your own SSH key. The key may be defined within the global config section, `config.ssh.private_key_path`, or within the provider config section, `provider.ssh_private_key_path`. The provider config will take precedence. Additionally, you may provide a name for the SSH key using the `ssh_key_name` attribute within the provider config section. This is useful for de-conflict SSH keys used by different individuals when creating machines on Digital Ocean.
 
 ```ruby
     config.vm.provider :digital_ocean do |provider|
         provider.ssh_key_name = "My Laptop"
-        provider.pub_ssh_key_path = "~/.ssh/id_rsa.pub"
+        provider.ssh_private_key_path = "~/.ssh/id_rsa.pub"
 
         # additional configuration here
     end
 ```
 
-The provider will assume the private key path is identical to the public key path without the *.pub* extention. If this is not the case, define the private key path using `config.ssh.private_key_path`. If an SSH key name is not set, it will default to *Vagrant*.
-
-## Status
-
-As of this writing the provider implementation is geared entirely toward a development workflow. That is, Digital Ocean droplets are meant to be used as a replacement for VirtualBox in a server developers workflow.
+The provider will assume the public key path is identical to the private key path with the *.pub* extention.
 
 ## Supported Guests/Hosts
 
@@ -67,7 +63,7 @@ Vagrant.configure("2") do |config|
     vm.region = "New York 1"
     vm.size = "512MB"
     vm.ssh_key_name = "My Key"
-    vm.pub_ssh_key_path = "~/.ssh/id_rsa"
+    vm.ssh_private_key_path = "~/.ssh/id_rsa"
 
     # optional config for SSL cert on OSX and others
     vm.ca_path = "/usr/local/etc/openssl/ca-bundle.crt"

--- a/lib/vagrant-digitalocean.rb
+++ b/lib/vagrant-digitalocean.rb
@@ -8,12 +8,5 @@ module VagrantPlugins
     def self.source_root
       @source_root ||= Pathname.new(File.expand_path('../../', __FILE__))
     end
-
-    def self.vagrant_key
-      file = File.open(Vagrant.source_root + "keys/vagrant.pub")
-      key = file.read
-      file.close
-      key
-    end
   end
 end

--- a/lib/vagrant-digitalocean/action.rb
+++ b/lib/vagrant-digitalocean/action.rb
@@ -5,6 +5,7 @@ require "vagrant-digitalocean/actions/setup_nfs"
 require "vagrant-digitalocean/actions/setup_sudo"
 require "vagrant-digitalocean/actions/setup_user"
 require "vagrant-digitalocean/actions/create"
+require "vagrant-digitalocean/actions/setup_ssh_key"
 
 module VagrantPlugins
   module DigitalOcean
@@ -44,9 +45,6 @@ module VagrantPlugins
           # sort out sudo for redhat, etc
           builder.use Actions::SetupSudo
 
-          # sort out sudo for redhat, etc
-          builder.use Actions::SetupUser
-
           # execute provisioners
           builder.use Provision
 
@@ -65,6 +63,8 @@ module VagrantPlugins
         # TODO figure out when to exit if the vm is created
         return Vagrant::Action::Builder.new.tap do |builder|
           builder.use ConfigValidate
+
+          builder.use Actions::SetupSSHKey
 
           # build the vm if necessary
           builder.use Actions::Create

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -20,22 +20,7 @@ module VagrantPlugins
             return @app.call(env)
           end
 
-          # TODO check the content of the key to see if it has changed
-          ssh_key_name = env[:machine].provider_config.ssh_key_name
-          begin
-            ssh_key_id = @client
-              .request("/ssh_keys/")
-              .find_id(:ssh_keys, :name => ssh_key_name)
-          rescue Errors::ResultMatchError
-            env[:ui].info @translator.t("create_key")
-
-            result = @client.request("/ssh_keys/new", {
-              :name => ssh_key_name,
-              :ssh_pub_key => pub_ssh_key(env)
-            })
-
-            ssh_key_id = result["ssh_key"]["id"]
-          end
+          ssh_key_id = env[:ssh_key_id]
 
           size_id = @client
             .request("/sizes")
@@ -96,19 +81,6 @@ module VagrantPlugins
           destroy_env[:force_confirm_destroy] = true
           env[:action_runner].run(Action.new.destroy, destroy_env)
         end
-
-        private
-
-        def pub_ssh_key(env)
-          path = env[:machine].provider_config.pub_ssh_key_path
-          file = File.open(File.expand_path(path))
-          key = file.read
-          file.close
-          key
-        rescue
-          env[:ui].info @translator.t("key_not_found")
-          DigitalOcean.vagrant_key
-        end 
       end
     end
   end

--- a/lib/vagrant-digitalocean/actions/destroy.rb
+++ b/lib/vagrant-digitalocean/actions/destroy.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
               next if env[:interrupted]
 
               # Wait for the server to be ready
-              raise "not off" if env[:machine].state.id != :off
+              raise "not off" if env[:machine].state.id != :archive
             end
           else
             env[:ui].info @translator.t("not_active_or_new")

--- a/lib/vagrant-digitalocean/actions/setup_ssh_key.rb
+++ b/lib/vagrant-digitalocean/actions/setup_ssh_key.rb
@@ -1,0 +1,60 @@
+require "vagrant-digitalocean/helpers/client"
+
+module VagrantPlugins
+  module DigitalOcean
+    module Actions
+      class SetupSSHKey
+        include Helpers::Client
+  
+        def initialize(app, env)
+          @app, @env = app, env
+          @client = client
+          @translator = Helpers::Translator.new("actions.setup_ssh_key")
+        end
+
+        # TODO check the content of the key to see if it has changed
+        def call(env)
+          ssh_key_name = env[:machine].provider_config.ssh_key_name
+
+          begin
+            # assigns existing ssh key id to env for use by other commands
+            env[:ssh_key_id] = @client
+              .request("/ssh_keys/")
+              .find_id(:ssh_keys, :name => ssh_key_name)
+
+            env[:ui].info @translator.t("existing_key", { :name => ssh_key_name })
+          rescue Errors::ResultMatchError
+            env[:ssh_key_id] = create_ssh_key(ssh_key_name, env)
+          end
+
+          @app.call(env)
+        end
+
+        private
+
+        def create_ssh_key(name, env)
+          # assumes public key exists on the same path as private key with .pub ext
+          path = env[:machine].provider_config.ssh_private_key_path
+          path = env[:machine].config.ssh.private_key_path if !path
+          path = File.expand_path("#{path}.pub", env[:machine].env.root_path)
+
+          env[:ui].info @translator.t("new_key", { :name => name, :path => path })
+          begin
+            file = File.open(path)
+            key = file.read
+            file.close
+          rescue
+            raise Errors::PublicKeyError,
+              :path => path
+          end
+
+          result = @client.request("/ssh_keys/new", {
+            :name => name,
+            :ssh_pub_key => key
+          })
+          result["ssh_key"]["id"]
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module DigitalOcean
     class Config < Vagrant.plugin("2", :config)
       attr_accessor :client_id, :api_key, :image, :region, :size, :ca_path,
-                    :ssh_key_name, :pub_ssh_key_path
+                    :ssh_key_name, :ssh_private_key_path
 
       def initialize
         @client_id        = UNSET_VALUE
@@ -13,23 +13,36 @@ module VagrantPlugins
         @ca_path          = UNSET_VALUE
         @ssh_key_name     = UNSET_VALUE
         @pub_ssh_key_path = UNSET_VALUE
+
+        @translator = Helpers::Translator.new("config")
       end
 
       def finalize!
-        @client_id         = ENV["DO_CLIENT_ID"] if @client_id == UNSET_VALUE
-        @api_key           = ENV["DO_API_KEY"] if @api_key == UNSET_VALUE
-        @image             = "Ubuntu 12.04 x32 Server" if @image == UNSET_VALUE
-        @region            = "New York 1" if @region == UNSET_VALUE
-        @size              = "512MB" if @size == UNSET_VALUE
-        @ca_path           = nil if @ca_path == UNSET_VALUE
-        @ssh_key_name      = "Vagrant" if @ssh_key_name == UNSET_VALUE
-        @pub_ssh_key_path  = nil if @pub_ssh_key_path == UNSET_VALUE
+        @client_id             = ENV["DO_CLIENT_ID"] if @client_id == UNSET_VALUE
+        @api_key               = ENV["DO_API_KEY"] if @api_key == UNSET_VALUE
+        @image                 = "Ubuntu 12.04 x32 Server" if @image == UNSET_VALUE
+        @region                = "New York 1" if @region == UNSET_VALUE
+        @size                  = "512MB" if @size == UNSET_VALUE
+        @ca_path               = nil if @ca_path == UNSET_VALUE
+        @ssh_key_name          = "Vagrant" if @ssh_key_name == UNSET_VALUE
+        @ssh_private_key_path  = nil if @ssh_private_key_path == UNSET_VALUE
       end
 
       def validate(machine)
         errors = []
-        errors << "Client ID required" if !@client_id
-        errors << "API Key required" if !@api_key
+        errors << @translator.t(:client_id_required) if !@client_id
+        errors << @translator.t(:api_key_required) if !@api_key
+
+        key = @ssh_private_key_path
+        key = machine.config.ssh.private_key_path if !@ssh_private_key_path
+
+        if !key
+          errors << @translator.t(:private_key_required) if !key
+        elsif !File.file?(File.expand_path(key, machine.env.root_path))
+          errors << @translator.t(:private_key_missing, { :key => key })
+        elsif !File.file?(File.expand_path("#{key}.pub", machine.env.root_path))
+          errors << @translator.t(:public_key_missing, { :key => key })
+        end
 
         { "Digital Ocean Provider" => errors }
       end

--- a/lib/vagrant-digitalocean/errors.rb
+++ b/lib/vagrant-digitalocean/errors.rb
@@ -26,6 +26,10 @@ module VagrantPlugins
       class LocalIPError < DigitalOceanError
         error_key(:local_ip)
       end
+
+      class PublicKeyError < DigitalOceanError
+        error_key(:public_key)
+      end
     end
   end
 end

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -57,19 +57,14 @@ module VagrantPlugins
 
         return nil if state["status"] == :not_created
 
-        if @machine.config.ssh.private_key_path
-          private_key_path = @machine.config.ssh.private_key_path
-        elsif @machine.provider_config.pub_ssh_key_path
-          private_key_path = @machine.provider_config.pub_ssh_key_path.chomp(".pub")
-        else
-          private_key_path = Vagrant.source_root + "keys/vagrant"
-        end
+        # TODO submit patch to chef provisioner to read ssh username from ssh_info
+        @machine.config.ssh.username = "root"
 
         return {
           :host => state["ip_address"],
           :port => "22",
           :username => "root",
-          :private_key_path => private_key_path
+          :private_key_path => @machine.provider_config.ssh_private_key_path
         }
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,6 +1,13 @@
 en:
   vagrant_digital_ocean:
+    config:
+      client_id_required: "Client ID required"
+      api_key_required: "API key required"
+      private_key_required: "SSH private key path required"
+      private_key_missing: "SSH private key is missing: %{key}"
+      public_key_missing: "SSH public key is missing: %{key}.pub"
     errors:
+      public_key: "Failed to read public key: %{path}"
       api_status: |-
         There was an issue with the request made to the Digital Ocean
         API at:
@@ -49,10 +56,8 @@ en:
     actions:
       create:
         skip: "Droplet is active, skipping creation"
-        create_key: "Adding key client account"
         create_droplet: "Creating the droplet"
         wait_active: "Waiting for the droplet to become active (>= 1 min)"
-        key_not_found: "Public SSH key not provided, using insecure Vagrant key"
       destroy:
         destroying: "Destroying droplet"
         not_active_or_new: "Droplet not in the `active` or `new` state"
@@ -71,3 +76,7 @@ en:
         create: "Creating user '%{user}' and setting password"
         sudo: "Enabling sudo for user '%{user}'"
         key: "Adding public key to authorized_keys"
+      setup_ssh_key:
+        existing_key: "Using existing SSH key: %{name}"
+        insecure_key: "Using default insecure vagrant SSH key"
+        new_key: "Creating new SSH key: %{name} (%{path})"

--- a/test/Vagrantfile.centos
+++ b/test/Vagrantfile.centos
@@ -1,5 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "digital_ocean"
+  config.ssh.private_key_path = "test_id_rsa"
 
   config.vm.provider :digital_ocean do |vm|
     vm.client_id = ENV["DO_CLIENT_ID"]

--- a/test/Vagrantfile.ubuntu
+++ b/test/Vagrantfile.ubuntu
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
     vm.region = "New York 1"
     vm.size = "512MB"
     vm.ssh_key_name = "Test Key"
-    vm.pub_ssh_key_path = "test_id_rsa.pub"
+    vm.ssh_private_key_path = "test_id_rsa"
   end
 
   config.vm.provision :shell, :path => "provision.sh"


### PR DESCRIPTION
This PR refactors ssh key support into its own middleware in preparation for implementing a rebuild command. It changes configuration to align more closely with Vagrant defaults -- specifically a user defines his key using config.ssh.private_key_path or provider.ssh_private_key_path. The public key is derived from the private key path by adding the .pub extension.

It drops supports for the Vagrant insecure key. An error will be raised if the user does not define his own private key path. Additionally, the setup of a new user (which was hardcoded to the vagrant user) was dropped. This was done for two reasons:
- the creation of new users should be left to the individual using the provider via custom provisioning
- security of new machine was greatly improved; by default the provider creates a new machine that can only be accessed via a user-defined SSH key (vs a known vagrant user/password combination)
