### PR TITLE
Support a user-specified SSH username.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Vagrant Digital Ocean
 
-`vagrant-digitalocean` is a provider plugin for Vagrant that allows the management of [Digital Ocean](https://www.digitalocean.com/) droplets (instances).
+`vagrant-digitalocean` is a provider plugin for Vagrant that allows the
+management of [Digital Ocean](https://www.digitalocean.com/) droplets
+(instances).
 
-## SSH Keys
+## SSH Authentication
 
-This provider does not support the use of Vagrant's insecure key for SSH access. You must specify your own SSH key. The key may be defined within the global config section, `config.ssh.private_key_path`, or within the provider config section, `provider.ssh_private_key_path`. The provider config will take precedence. Additionally, you may provide a name for the SSH key using the `ssh_key_name` attribute within the provider config section. This is useful for de-conflict SSH keys used by different individuals when creating machines on Digital Ocean.
+This provider does not support the use of Vagrant's insecure key for SSH
+access. You must specify your own SSH key. The key may be defined within
+the global config section, `config.ssh.private_key_path`, or within the
+provider config section, `provider.ssh_private_key_path`. The provider
+config will take precedence. Additionally, you may provide a name for
+the SSH key using the `ssh_key_name` attribute within the provider config
+section. This is useful for de-conflict SSH keys used by different
+individuals when creating machines on Digital Ocean.
 
 ```ruby
     config.vm.provider :digital_ocean do |provider|
@@ -15,15 +24,24 @@ This provider does not support the use of Vagrant's insecure key for SSH access.
     end
 ```
 
-The provider will assume the public key path is identical to the private key path with the *.pub* extention.
+The provider will assume the public key path is identical to the private
+key path with the *.pub* extention.
+
+By default, the provider uses the `root` account for SSH access. This is
+required for initial droplet creation and provisioning. You may specify
+an account that may be used for subsequent SSH access and provisioning
+by setting the `ssh_username` attribute within the provider config
+section.
 
 ## Supported Guests/Hosts
 
-This project is primarily to support my workflow which currently only involves Ubuntu and CentOS. It's likely that any unix host will work but I've not tested it. Guests require porting of the nfs, chef, and sudo setup scripts.
+The project is currently in alpha state and has been tested on the
+following hosts and guests:
 
 Hosts:
 
 * Ubuntu 12.04
+* Mac OS X
 
 Guests:
 
@@ -32,7 +50,9 @@ Guests:
 
 ## Supported Provisioners
 
-The shell provisioner is supported by default but other provisioners require bootstrapping on the server. Chef is currently the only supported provisioner. Adding support for puppet and others requires adding the install scripts.
+The shell provisioner is supported by default but other provisioners require
+bootstrapping on the server. Chef is currently the only supported provisioner.
+Adding support for puppet and others requires adding the install scripts.
 
 ## Installation
 
@@ -40,13 +60,16 @@ Installation is performed in the prescribed manner for Vagrant 1.1 plugins.
 
     vagrant plugin install vagrant-digitalocean
 
-In addition to installing the plugin the default box associated with the provider needs to be installed.
+In addition to installing the plugin the default box associated with the
+provider needs to be installed.
 
     vagrant box add digital_ocean https://raw.github.com/johnbender/vagrant-digitalocean/master/box/digital_ocean.box
 
 ## Usage
 
-To use the Digital Ocean provider you will need to visit the [API access page](https://www.digitalocean.com/api_access) to retrieve the client identifier and API key associated with your account.
+To use the Digital Ocean provider you will need to visit the
+[API access page](https://www.digitalocean.com/api_access) to retrieve
+the client identifier and API key associated with your account.
 
 ### Config
 
@@ -64,6 +87,7 @@ Vagrant.configure("2") do |config|
     vm.size = "512MB"
     vm.ssh_key_name = "My Key"
     vm.ssh_private_key_path = "~/.ssh/id_rsa"
+    vm.ssh_username = "test"
 
     # optional config for SSL cert on OSX and others
     vm.ca_path = "/usr/local/etc/openssl/ca-bundle.crt"

--- a/bin/test_run.sh
+++ b/bin/test_run.sh
@@ -1,8 +1,10 @@
 function run_test_for {
   cp Vagrantfile.$1 Vagrantfile
   vagrant up --provider=digital_ocean
+  vagrant up
   vagrant provision
   vagrant rebuild
+  vagrant destroy
   vagrant destroy
 }
 

--- a/lib/vagrant-digitalocean/actions/check_ssh_user.rb
+++ b/lib/vagrant-digitalocean/actions/check_ssh_user.rb
@@ -1,0 +1,46 @@
+module VagrantPlugins
+  module DigitalOcean
+    module Actions
+      class CheckSSHUser
+        include Vagrant::Util::Counter
+
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @translator = Helpers::Translator.new("actions.check_ssh_user")
+        end
+
+        def call(env)
+          # return if the machine is set with the default ssh username
+          return @app.call(env) if @machine.ssh_info()[:username] == "root"
+
+          # check if ssh username account has been provisioned
+          begin
+            tries = @machine.config.ssh.max_tries
+            @machine.config.ssh.max_tries = 0
+            @machine.communicate.execute("echo")
+          rescue Vagrant::Errors::SSHAuthenticationFailed
+            original_username = @machine.ssh_info()[:username]
+            @machine.provider_config.ssh_username = "root"
+            env[:ui].info @translator.t('fallback', {
+              :user => original_username
+            })
+
+            # TODO remove when vagrant chef provisioning defect fixed
+            @machine.config.ssh.username = "root"
+          end
+
+          @machine.config.ssh.max_tries = tries
+
+          @app.call(env)
+
+          # reset ssh username
+          @machine.provider_config.ssh_username = original_username
+
+          # TODO remove when vagrant chef provisioning defect fixed
+          @machine.config.ssh.username = original_username
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -14,12 +14,6 @@ module VagrantPlugins
         end
 
         def call(env)
-          # if the machine state is created skip
-          if env[:machine].state.id == :active
-            env[:ui].info @translator.t("skip")
-            return @app.call(env)
-          end
-
           ssh_key_id = env[:ssh_key_id]
 
           size_id = @client
@@ -45,30 +39,11 @@ module VagrantPlugins
             :ssh_key_ids => ssh_key_id
           })
 
+          env[:ui].info @translator.t("wait_active")
+          @client.wait_for_event(result["droplet"]["event_id"])
+
           # assign the machine id for reference in other commands
           env[:machine].id = result["droplet"]["id"].to_s
-
-          env[:ui].info @translator.t("wait_active")
-
-          # TODO refactor to use wait_for_event method
-          retryable(:tries => 30, :sleep => 10) do
-            # If we're interrupted don't worry about waiting
-            next if env[:interrupted]
-
-            # Wait for the server to be ready
-            raise "not ready" if env[:machine].state.id != :active
-          end
-
-          retryable(:tries => 30, :sleep => 2) do
-            # If we're interrupted don't worry about waiting
-            next if env[:interrupted]
-
-            # Wait for the server to be ready for ssh
-            env[:machine].communicate.execute("echo");
-          end
-
-          # signal that the machine has just been created, used in ReadState
-          env[:machine_just_created] = true
 
           @app.call(env)
         end

--- a/lib/vagrant-digitalocean/actions/destroy.rb
+++ b/lib/vagrant-digitalocean/actions/destroy.rb
@@ -14,19 +14,13 @@ module VagrantPlugins
         end
 
         def call(env)
-          if [:active, :new].include?(env[:machine].state.id)
-            # submit destroy droplet request
-            env[:ui].info @translator.t("destroying")
-            result = @client.request("/droplets/#{env[:machine].id}/destroy")
+          # submit destroy droplet request
+          env[:ui].info @translator.t("destroying")
+          result = @client.request("/droplets/#{env[:machine].id}/destroy")
 
-            # wait for request to complete
-            env[:ui].info @translator.t("wait_off")
-
-            @client.wait_for_event(result["event_id"])
-          else
-
-            env[:ui].info @translator.t("not_active_or_new")
-          end
+          # wait for request to complete
+          env[:ui].info @translator.t("wait_off")
+          @client.wait_for_event(result["event_id"])
 
           @app.call(env)
         end

--- a/lib/vagrant-digitalocean/actions/is_active.rb
+++ b/lib/vagrant-digitalocean/actions/is_active.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module DigitalOcean
+    module Actions
+      class IsActive
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:is_active] = env[:machine].state.id == :active
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-digitalocean/actions/message_is_active.rb
+++ b/lib/vagrant-digitalocean/actions/message_is_active.rb
@@ -1,0 +1,18 @@
+module VagrantPlugins
+  module DigitalOcean
+    module Actions
+      class MessageIsActive
+        def initialize(app, env)
+          @app = app
+          @translator = Helpers::Translator.new("actions.message_is_active")
+        end
+
+        def call(env)
+          msg = env[:is_active] ? "active" : "not_active"
+          env[:ui].info @translator.t(msg)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-digitalocean/actions/modify_provision_path.rb
+++ b/lib/vagrant-digitalocean/actions/modify_provision_path.rb
@@ -1,0 +1,40 @@
+module VagrantPlugins
+  module DigitalOcean
+    module Actions
+      class ModifyProvisionPath
+        include Vagrant::Util::Counter
+
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @translator =
+            Helpers::Translator.new("actions.modify_provision_path")
+        end
+
+        def call(env)
+          username = @machine.ssh_info()[:username]
+          env[:ui].info @translator.t("modify", { :user => username })
+
+          # modify provisioning paths to enable different users to
+          # provision the same machine
+          #
+          # TODO submit patch to vagrant to set appropriate permissions
+          # based on ssh username
+          @machine.communicate.execute("mkdir -p /home/#{username}/tmp")
+          env[:global_config].vm.provisioners.each do |prov|
+            if prov.name == :shell
+              prov.config.upload_path =
+                prov.config.upload_path.prepend("/home/#{username}")
+            else
+              counter = get_and_update_counter(:provisioning_path)
+              path = "/home/#{username}/tmp/vagrant-chef-#{counter}"
+              prov.config.provisioning_path = path
+            end
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-digitalocean/actions/rebuild.rb
+++ b/lib/vagrant-digitalocean/actions/rebuild.rb
@@ -13,12 +13,6 @@ module VagrantPlugins
         end
 
         def call(env)
-          # ensure the machine is in an active state
-          if env[:machine].state.id != :active
-            env[:ui].info @translator.t("skip")
-            return @app.call(env)
-          end
-
           # look up image id
           image_id = @client
             .request("/images", { :filter => "global" })

--- a/lib/vagrant-digitalocean/actions/sync_folders.rb
+++ b/lib/vagrant-digitalocean/actions/sync_folders.rb
@@ -30,9 +30,9 @@ module VagrantPlugins
                                         :guestpath => guestpath)
 
             # Create the guest path
-            env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
+            env[:machine].communicate.sudo("mkdir -p #{guestpath}")
             env[:machine].communicate.sudo(
-              "chown #{ssh_info[:username]} '#{guestpath}'")
+              "chown -R #{ssh_info[:username]} #{guestpath}")
 
             # Rsync over to the guest path using the SSH info
             command = [

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -2,17 +2,18 @@ module VagrantPlugins
   module DigitalOcean
     class Config < Vagrant.plugin("2", :config)
       attr_accessor :client_id, :api_key, :image, :region, :size, :ca_path,
-                    :ssh_key_name, :ssh_private_key_path
+                    :ssh_key_name, :ssh_private_key_path, :ssh_username
 
       def initialize
-        @client_id        = UNSET_VALUE
-        @api_key          = UNSET_VALUE
-        @image            = UNSET_VALUE
-        @region           = UNSET_VALUE
-        @size             = UNSET_VALUE
-        @ca_path          = UNSET_VALUE
-        @ssh_key_name     = UNSET_VALUE
-        @pub_ssh_key_path = UNSET_VALUE
+        @client_id            = UNSET_VALUE
+        @api_key              = UNSET_VALUE
+        @image                = UNSET_VALUE
+        @region               = UNSET_VALUE
+        @size                 = UNSET_VALUE
+        @ca_path              = UNSET_VALUE
+        @ssh_key_name         = UNSET_VALUE
+        @ssh_private_key_path = UNSET_VALUE
+        @ssh_username         = UNSET_VALUE
 
         @translator = Helpers::Translator.new("config")
       end
@@ -26,6 +27,7 @@ module VagrantPlugins
         @ca_path               = nil if @ca_path == UNSET_VALUE
         @ssh_key_name          = "Vagrant" if @ssh_key_name == UNSET_VALUE
         @ssh_private_key_path  = nil if @ssh_private_key_path == UNSET_VALUE
+        @ssh_username          = "root" if @ssh_username == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -57,13 +57,13 @@ module VagrantPlugins
 
         return nil if state["status"] == :not_created
 
-        # TODO submit patch to chef provisioner to read ssh username from ssh_info
-        @machine.config.ssh.username = "root"
+        # TODO remove when defect in vagrant chef provisioner is fixed
+        @machine.config.ssh.username = @machine.provider_config.ssh_username
 
         return {
           :host => state["ip_address"],
           :port => "22",
-          :username => "root",
+          :username => @machine.provider_config.ssh_username,
           :private_key_path => @machine.provider_config.ssh_private_key_path
         }
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -64,34 +64,28 @@ en:
 
     actions:
       create:
-        skip: "Droplet is active, skipping creation"
         create_droplet: "Creating the droplet"
         wait_active: "Waiting for the droplet to become active (>= 1 min)"
       rebuild:
-        skip: "Droplet is not active, skipping rebuild"
         rebuild: "Rebuilding the droplet"
         wait: "Waiting for the droplet to rebuild (>= 1 min)"
       destroy:
         destroying: "Destroying droplet"
-        not_active_or_new: "Droplet not in the `active` or `new` state"
-        clean_nfs: "Cleaning up NFS exports, may require sudo password"
         wait_off: "Waiting for the droplet to be destroyed"
       setup_sudo:
         exec: "Making alterations to the sudoers file where necessary"
-      setup_nfs:
-        machine_ip: "Droplet IP: %{ip}"
-        host_ip: "Host IP: %{ip}"
-        install: "Installing NFS on the droplet"
-        force_shared_folders: "Forcing shared folders to use NFS where necessary"
       setup_provisioner:
         install: "Installing provisioner: %{provisioner} (>= 2 min)"
-      setup_user:
-        create: "Creating user '%{user}' and setting password"
-        sudo: "Enabling sudo for user '%{user}'"
-        key: "Adding public key to authorized_keys"
       sync_folders:
         rsync_folder: "Rsyncing folder: %{hostpath} => %{guestpath}"
       setup_ssh_key:
         existing_key: "Using existing SSH key: %{name}"
         insecure_key: "Using default insecure vagrant SSH key"
         new_key: "Creating new SSH key: %{name} (%{path})"
+      message_is_active:
+        active: "Droplet is already active"
+        not_active: "Droplet is not active"
+      check_ssh_user:
+        fallback: "Failed to authenticate with '%{user}', falling back to 'root'"
+      modify_provision_path:
+        modify: "Modifying provisioning path to '/home/%{user}/tmp'"

--- a/test/Vagrantfile.ubuntu
+++ b/test/Vagrantfile.ubuntu
@@ -9,9 +9,10 @@ Vagrant.configure("2") do |config|
     vm.size = "512MB"
     vm.ssh_key_name = "Test Key"
     vm.ssh_private_key_path = "test_id_rsa"
+    vm.ssh_username = "tester"
   end
 
-  config.vm.provision :shell, :path => "provision.sh"
+  config.vm.provision :shell, :path => "scripts/setup_user.sh"
 
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = "cookbooks"

--- a/test/scripts/setup_user.sh
+++ b/test/scripts/setup_user.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if ! grep tester /etc/passwd; then
+    useradd -m -s /bin/bash tester
+fi
+
+if ! grep tester /etc/sudoers; then
+    echo "tester ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+fi
+
+mkdir -p /home/tester/.ssh
+chown tester:tester /home/tester/.ssh
+
+pub_key="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbFlHJ++BcXGU9b2K+jF990r16uqkKnWiK2CFS0PFvM9IJs3CoGiIlyc9UD9O4LEyeu5Rw0RdiAp9MvyUPcDUeibw3WlMCFJ53mbioAapMy5tPXmxxJH5KcN2uJKESsH/1hJv0tWfVpHQywVLcf/7HWPjDl3qEFqzwGEN+5V3XqyG+hoA4rLTLDL40G68bL/oC7ere3sz3B16U4NGdgtJZapot5gTFErFZZztql76h25Ch7isE1XAaYg6NY4z1oU8Q9Ud0sY74tDI8TF165LStb3prf1TinwaMbOyuQ1wrNU4aMzekiwazeo6LtHMnfPjweIGP01PwjZ8WkYcRF6tt digital_ocean provider test key"
+
+if ! [ -e /home/tester/.ssh/authorized_keys ]; then
+    echo "${pub_key}" > /home/tester/.ssh/authorized_keys
+fi


### PR DESCRIPTION
This commit enables the user to specify a SSH username for the
provider using the `ssh_username` config attribute. For the initial
droplet creation and provisioning, the provider will fallback to the
`root` user. On subsequent execution of Vagrant commands, the
specified SSH username will be attempted instead. The user should
create the SSH username account during the provisioning process.

Additionally, better state checking for a droplet was implemented.
If a droplet is already active, calling `up` will have no effect. The
same is true when calling `destroy`, `provision`, or `rebuild` after a
droplet has been destroyed.

Closes #23 and #25.
