### PR TITLE
Implement disabled option for synced folders.

### DIFF
--- a/lib/vagrant-digitalocean/actions/sync_folders.rb
+++ b/lib/vagrant-digitalocean/actions/sync_folders.rb
@@ -18,6 +18,8 @@ module VagrantPlugins
           ssh_info = env[:machine].ssh_info
 
           env[:machine].config.vm.synced_folders.each do |id, data|
+            next if data[:disabled]
+
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]
 

--- a/test/Vagrantfile.centos
+++ b/test/Vagrantfile.centos
@@ -4,6 +4,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "digital_ocean"
   config.ssh.private_key_path = "test_id_rsa"
 
+  config.vm.synced_folder '/vagrant', '.', :id => 'vagrant-root', :disabled => true
+
   config.vm.provider :digital_ocean do |vm|
     vm.client_id = ENV["DO_CLIENT_ID"]
     vm.api_key = ENV["DO_API_KEY"]


### PR DESCRIPTION
This commit mimics the VirtualBox provider allowing a user to
disable a synced folder. This is useful for disabling the default
vagrant-root folder.
