### PR TITLE
Detect and install rsync if missing.

### DIFF
--- a/lib/vagrant-digitalocean/actions/sync_folders.rb
+++ b/lib/vagrant-digitalocean/actions/sync_folders.rb
@@ -33,6 +33,8 @@ module VagrantPlugins
             @machine.communicate.sudo(
               "chown -R #{ssh_info[:username]} #{guestpath}")
 
+            verify_rsync
+
             # rsync over to the guest path using the ssh info
             command = [
               "rsync", "--verbose", "--archive", "-z",
@@ -50,6 +52,16 @@ module VagrantPlugins
           end
 
           @app.call(env)
+        end
+
+        def verify_rsync
+          begin
+            @machine.communicate.execute("rsync")
+          rescue
+            @logger.debug("Rsync binary not found. Installing.")
+            @machine.communicate.sudo("apt-get update")
+            @machine.communicate.sudo("apt-get install rsync")
+          end
         end
       end
     end


### PR DESCRIPTION
On some older guest OS's rsync is not available by default, this patch checks if rsync is available and installs it if it is missing.
