### PR TITLE
Updates timeouts for larger machine creation

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
           # wait for ssh to be ready using the root user account
           user = @machine.config.ssh.username
           @machine.config.ssh.username = 'root'
-          retryable(:tries => 30, :sleep => 10) do
+          retryable(:tries => 120, :sleep => 10) do
             next if env[:interrupted]
             raise 'not ready' if !@machine.communicate.ready?
           end

--- a/lib/vagrant-digitalocean/helpers/client.rb
+++ b/lib/vagrant-digitalocean/helpers/client.rb
@@ -68,7 +68,7 @@ module VagrantPlugins
         end
 
         def wait_for_event(env, id)
-          retryable(:tries => 30, :sleep => 10) do
+          retryable(:tries => 120, :sleep => 10) do
             # stop waiting if interrupted
             next if env[:interrupted]
 


### PR DESCRIPTION
Updates the timeout values for the client and server creation so larger machine instances will not timeout during this process.
