### PR TITLE
Allow `rebuild` even if the machine is switched off

### DIFF
--- a/lib/vagrant-digitalocean/actions.rb
+++ b/lib/vagrant-digitalocean/actions.rb
@@ -139,13 +139,11 @@ module VagrantPlugins
           builder.use ConfigValidate
           builder.use Call, CheckState do |env, b|
             case env[:machine_state]
-            when :active
+            when :active, :off
               b.use Rebuild
               b.use SetupSudo
               b.use SetupUser
               b.use provision
-            when :off
-              env[:ui].info I18n.t('vagrant_digital_ocean.info.off')
             when :not_created
               env[:ui].info I18n.t('vagrant_digital_ocean.info.not_created')
             end

--- a/lib/vagrant-digitalocean/actions/rebuild.rb
+++ b/lib/vagrant-digitalocean/actions/rebuild.rb
@@ -28,6 +28,9 @@ module VagrantPlugins
           env[:ui].info I18n.t('vagrant_digital_ocean.info.rebuilding')
           @client.wait_for_event(env, result['event_id'])
 
+          # refresh droplet state with provider
+          Provider.droplet(@machine, :refresh => true)
+
           @app.call(env)
         end
       end


### PR DESCRIPTION
There shouldn't be any reason why a halted machine couldn't be rebuilt. It is also possible via the web UI.

We only need to refresh the machine state after the rebuild.
