### PR TITLE
remove image filter

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             .find_id(:sizes, :name => @machine.provider_config.size)
 
           image_id = @client
-            .request('/images', { :filter => 'global' })
+            .request('/images')
             .find_id(:images, :name => @machine.provider_config.image)
 
           region_id = @client


### PR DESCRIPTION
I don't know why images reported by the DO api get filtered. Without that filter snapshots or backups could be used as images for new droplets. Should resolve [#40](https://github.com/smdahlen/vagrant-digitalocean/issues/40)
