### PR TITLE
Updated config.rb for new Digital Ocean Defaults

### DIFF
--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -22,8 +22,8 @@ module VagrantPlugins
       def finalize!
         @client_id    = ENV['DO_CLIENT_ID'] if @client_id == UNSET_VALUE
         @api_key      = ENV['DO_API_KEY'] if @api_key == UNSET_VALUE
-        @image        = 'Ubuntu 12.04 x64 Server' if @image == UNSET_VALUE
-        @region       = 'New York 1' if @region == UNSET_VALUE
+        @image        = 'Ubuntu 12.04 x64' if @image == UNSET_VALUE
+        @region       = 'New York 2' if @region == UNSET_VALUE
         @size         = '512MB' if @size == UNSET_VALUE
         @ca_path      = nil if @ca_path == UNSET_VALUE
         @ssh_key_name = 'Vagrant' if @ssh_key_name == UNSET_VALUE


### PR DESCRIPTION
This updates the image and region to the new defaults for Digital Ocean:  Ubuntu 12.04 64 and New York 2, respectively.
