### PR TITLE
for vagrant v1.4 the ssh private_key_path is an array

### DIFF
--- a/lib/vagrant-digitalocean.rb
+++ b/lib/vagrant-digitalocean.rb
@@ -9,9 +9,9 @@ module VagrantPlugins
     end
 
     def self.public_key(private_key_path)
-      File.read("#{private_key_path}.pub") 
+      File.read("#{private_key_path[0]}.pub") 
     rescue
-      raise Errors::PublicKeyError, :path => "#{private_key_path}.pub"
+      raise Errors::PublicKeyError, :path => "#{private_key_path[0]}.pub"
     end
 
     I18n.load_path << File.expand_path('locales/en.yml', source_root)

--- a/lib/vagrant-digitalocean/actions/setup_key.rb
+++ b/lib/vagrant-digitalocean/actions/setup_key.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
 
         def create_ssh_key(name, env)
           # assumes public key exists on the same path as private key with .pub ext
-          path = @machine.config.ssh.private_key_path
+          path = @machine.config.ssh.private_key_path[0]
           path = File.expand_path(path, @machine.env.root_path)
           pub_key = DigitalOcean.public_key(path)
 

--- a/lib/vagrant-digitalocean/actions/setup_user.rb
+++ b/lib/vagrant-digitalocean/actions/setup_user.rb
@@ -41,7 +41,7 @@ module VagrantPlugins
           @machine.communicate.execute("su #{user} -c 'mkdir -p ~/.ssh'")
 
           # add the specified key to the authorized keys file
-          path = @machine.config.ssh.private_key_path
+          path = @machine.config.ssh.private_key_path[0]
           path = File.expand_path(path, @machine.env.root_path)
           pub_key = DigitalOcean.public_key(path)
           @machine.communicate.execute(<<-BASH)

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -42,7 +42,7 @@ module VagrantPlugins
         errors << I18n.t('vagrant_digital_ocean.config.client_id') if !@client_id
         errors << I18n.t('vagrant_digital_ocean.config.api_key') if !@api_key
 
-        key = machine.config.ssh.private_key_path
+        key = machine.config.ssh.private_key_path[0]
         if !key
           errors << I18n.t('vagrant_digital_ocean.config.private_key')
         elsif !File.file?(File.expand_path("#{key}.pub", machine.env.root_path))


### PR DESCRIPTION
This pull request is probably not acceptable as it does not work with versions of vagrant prior to 1.4 (which was released yesterday). I assume at least a version bump is in order.

I'd be more than happy to pursue a proper solution with a little guidance.

This patch allows me to create digital ocean droplets again, where it was failing with current head of master.
