### PR TITLE
Add ProvisionerCleanup to the destroy action middleware stack

### DIFF
--- a/lib/vagrant-digitalocean/actions.rb
+++ b/lib/vagrant-digitalocean/actions.rb
@@ -25,6 +25,7 @@ module VagrantPlugins
               env[:ui].info I18n.t('vagrant_digital_ocean.info.not_created')
             else
               b.use Destroy
+              b.use ProvisionerCleanup if defined?(ProvisionerCleanup)
             end
           end
         end


### PR DESCRIPTION
Call cleanup method of the provisioners (Vagrant >= 1.3.0).
This is used at least by chef-client provisioner to optionally delete the client and node from the Chef server.

Note: This depends on #79 as this action is otherwise never called by the Destroy action.
