### PR TITLE
Add confirmation for `vagrant destroy`

### DIFF
--- a/lib/vagrant-digitalocean/actions.rb
+++ b/lib/vagrant-digitalocean/actions.rb
@@ -24,8 +24,12 @@ module VagrantPlugins
             when :not_created
               env[:ui].info I18n.t('vagrant_digital_ocean.info.not_created')
             else
-              b.use Destroy
-              b.use ProvisionerCleanup if defined?(ProvisionerCleanup)
+              b.use Call, DestroyConfirm do |env2, b2|
+                if env2[:result]
+                  b2.use Destroy
+                  b2.use ProvisionerCleanup if defined?(ProvisionerCleanup)
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
The standard behavior is to ask confirmation from the user unless `--force/-f` option is specified.

This builds on top of #80. I'll rebase when that gets merged or declined. Unless this gets declined too, of course. =)
