### PR TITLE
fixing an invalid droplet name (the one currently hard-coded as default ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ end
 ```
 
 Please note the following:
-- You *must* specify the `config.ssh.private_key_path` to enable authentication
+- You *must* specify the `override.ssh.private_key_path` to enable authentication
   with the droplet. The provider will create a new Digital Ocean SSH key using
   your public key which is assumed to be the `private_key_path` with a *.pub*
   extension.
@@ -77,7 +77,7 @@ The following attributes are available to further configure the provider:
 - `provider.image` - A string representing the image to use when creating a
    new droplet (e.g. `Debian 6.0 x64`). The available options may
    be found on Digital Ocean's new droplet [form](https://www.digitalocean.com/droplets/new).
-   It defaults to `Ubuntu 12.04 x64`.
+   It defaults to `Ubuntu 12.04.3 x64`.
 - `provider.region` - A string representing the region to create the new
    droplet in. It defaults to `New York 2`.
 - `provider.size` - A string representing the size to use when creating a

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
       def finalize!
         @client_id          = ENV['DO_CLIENT_ID'] if @client_id == UNSET_VALUE
         @api_key            = ENV['DO_API_KEY'] if @api_key == UNSET_VALUE
-        @image              = 'Ubuntu 12.04 x64' if @image == UNSET_VALUE
+        @image              = 'Ubuntu 12.04.3 x64' if @image == UNSET_VALUE
         @region             = 'New York 2' if @region == UNSET_VALUE
         @size               = '512MB' if @size == UNSET_VALUE
         @private_networking = false if @private_networking == UNSET_VALUE

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :ubuntu do |ubuntu|
     ubuntu.vm.provider :digital_ocean do |provider|
-      provider.image = 'Ubuntu 12.04 x64'
+      provider.image = 'Ubuntu 12.04.3 x64'
     end
   end
 


### PR DESCRIPTION
...no longer exists, which causes things to fail unless it's overriden) and fixing a minor typo in documentation
