### PR TITLE
Replace link to Vagrant Cloud name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.provider :digital_ocean do |provider, override|
     override.ssh.private_key_path = '~/.ssh/id_rsa'
-    override.vm.box = 'digital_ocean'
-    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+    override.vm.box = 'AndrewDryga/digital-ocean'
     
     provider.client_id = 'YOUR CLIENT ID'
     provider.api_key = 'YOUR API KEY'


### PR DESCRIPTION
This is just an example, you can create box by you self. 

My box points directly to https://raw.githubusercontent.com/smdahlen/vagrant-digitalocean/master/box/digital_ocean.box so it's always up-to-date with your repo.

This should be carefully tested before merge :imp: 

P.S.: I had issues with adding box as link, also more kosher to create Vagrant file by calling:

``` bash
vagrant init AndrewDryga/digital-ocean
```

:)
