### PR TITLE
enable rsync__args option (and rsync__exclude)

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,6 +8,9 @@ Vagrant.configure('2') do |config|
   config.ssh.private_key_path = 'test_id_rsa'
 
   config.vm.synced_folder '.', '/vagrant', :disabled => true
+  config.vm.synced_folder '.', '/tmp/test', type: "rsync",
+    rsync__exclude: ['cookbooks/', 'scripts/'],
+    rsync__args: ['--verbose', '--archive', '--delete', '-z', '--progress']
 
   config.vm.provider :digital_ocean do |provider, override|
     override.vm.box = 'digital_ocean'


### PR DESCRIPTION
This enables the [rsync__args](http://docs.vagrantup.com/v2/synced-folders/rsync.html) option, which I wanted to use to pass the "--files-from=" option.

My edits would have created a merge conflict with the very related @sawanoboly pull request #110. So, I guessed it would be easiest for everyone if I first merged in that PR and built on top of it.

The rsync__args option needed vagrant >= 1.5, so the first commit here updates Gemfile like [here](http://docs.vagrantup.com/v2/plugins/development-basics.html), resulting in similarities to pull request #101 (commit 73f6e01).

This PR should offer a variety of options for issue #76 'rsync ignore files'.
