### PR TITLE
Update to use Ubuntu 14.04 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following attributes are available to further configure the provider:
 - `provider.image` - A string representing the image to use when creating a
    new droplet (e.g. `Debian 6.0 x64`). The available options may
    be found on Digital Ocean's new droplet [form](https://www.digitalocean.com/droplets/new).
-   It defaults to `Ubuntu 12.04.3 x64`.
+   It defaults to `Ubuntu 14.04.3 x64`.
 - `provider.region` - A string representing the region to create the new
    droplet in. It defaults to `New York 2`.
 - `provider.size` - A string representing the size to use when creating a

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
       def finalize!
         @client_id          = ENV['DO_CLIENT_ID'] if @client_id == UNSET_VALUE
         @api_key            = ENV['DO_API_KEY'] if @api_key == UNSET_VALUE
-        @image              = 'Ubuntu 12.04.3 x64' if @image == UNSET_VALUE
+        @image              = 'Ubuntu 14.04 x64' if @image == UNSET_VALUE
         @region             = 'New York 2' if @region == UNSET_VALUE
         @size               = '512MB' if @size == UNSET_VALUE
         @private_networking = false if @private_networking == UNSET_VALUE


### PR DESCRIPTION
14.04 is the default image on DO now, and this pull request makes it the one `vagrant-digitalocean` uses by default, too.
