### PR TITLE
Add vagrant-digitalocean to the 'plugins' group and update the tag from ...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.4.0'
+gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.6.3'
 gem 'vagrant-omnibus'
 gem 'rake'
+
+group :plugins do
+  gem 'vagrant-digitalocean', :path => '.'
+end
+
 gemspec


### PR DESCRIPTION
...which vagrant is used

This change allows you to `bundle exec vagrant --provider=digital_ocean`. Without the plugin being
in the 'plugins' group, it's difficult to test the plugin directly from the repo. See
https://docs.vagrantup.com/v2/plugins/packaging.html for more information.
