### PR TITLE
v2.0 API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 test/.vagrant
 tmp
+.vagrant

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Vagrant.configure('2') do |config|
     override.vm.box = 'digital_ocean'
     override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
     
-    provider.client_id = 'YOUR CLIENT ID'
-    provider.api_key = 'YOUR API KEY'
+    provider.token = 'YOUR TOKEN'
+    provider.image = 'Ubuntu 14.04 x64'
+    provider.region = 'nyc2'
+    provider.size = '512mb'
   end
 end
 ```
@@ -79,9 +81,9 @@ The following attributes are available to further configure the provider:
    be found on Digital Ocean's new droplet [form](https://www.digitalocean.com/droplets/new).
    It defaults to `Ubuntu 14.04.3 x64`.
 - `provider.region` - A string representing the region to create the new
-   droplet in. It defaults to `New York 2`.
+   droplet in. It defaults to `nyc2`.
 - `provider.size` - A string representing the size to use when creating a
-  new droplet (e.g. `1GB`). It defaults to `512MB`.
+  new droplet (e.g. `1gb`). It defaults to `512mb`.
 - `provider.private_networking` - A boolean flag indicating whether to enable
   a private network interface (if the region supports private networking). It
   defaults to `false`.

--- a/lib/vagrant-digitalocean/actions/destroy.rb
+++ b/lib/vagrant-digitalocean/actions/destroy.rb
@@ -15,14 +15,9 @@ module VagrantPlugins
 
         def call(env)
           # submit destroy droplet request
-          result = @client.request("/droplets/#{@machine.id}/destroy")
+          @client.delete("/v2/droplets/#{@machine.id}")
 
           env[:ui].info I18n.t('vagrant_digital_ocean.info.destroying')
-
-          # wait for the destroy progress to start
-          @client.wait_for_event(env, result['event_id']) do |response|
-            break if response['event']['percentage'] != nil
-          end
 
           # set the machine id to nil to cleanup local vagrant state
           @machine.id = nil

--- a/lib/vagrant-digitalocean/actions/power_off.rb
+++ b/lib/vagrant-digitalocean/actions/power_off.rb
@@ -1,5 +1,5 @@
 require 'vagrant-digitalocean/helpers/client'
-
+#TODO: --force
 module VagrantPlugins
   module DigitalOcean
     module Actions
@@ -15,11 +15,13 @@ module VagrantPlugins
 
         def call(env)
           # submit power off droplet request
-          result = @client.request("/droplets/#{@machine.id}/power_off")
+          result = @client.post("/v2/droplets/#{@machine.id}/actions", {
+            :type => 'power_off'
+          })
 
           # wait for request to complete
           env[:ui].info I18n.t('vagrant_digital_ocean.info.powering_off')
-          @client.wait_for_event(env, result['event_id'])
+          @client.wait_for_event(env, result['action']['id'])
 
           # refresh droplet state with provider
           Provider.droplet(@machine, :refresh => true)

--- a/lib/vagrant-digitalocean/actions/power_on.rb
+++ b/lib/vagrant-digitalocean/actions/power_on.rb
@@ -15,11 +15,13 @@ module VagrantPlugins
 
         def call(env)
           # submit power on droplet request
-          result = @client.request("/droplets/#{@machine.id}/power_on")
+          result = @client.post("/v2/droplets/#{@machine.id}/actions", {
+            :type => 'power_on'
+          })
 
           # wait for request to complete
           env[:ui].info I18n.t('vagrant_digital_ocean.info.powering_on') 
-          @client.wait_for_event(env, result['event_id'])
+          @client.wait_for_event(env, result['action']['id'])
 
           # refresh droplet state with provider
           Provider.droplet(@machine, :refresh => true)

--- a/lib/vagrant-digitalocean/actions/rebuild.rb
+++ b/lib/vagrant-digitalocean/actions/rebuild.rb
@@ -17,17 +17,18 @@ module VagrantPlugins
         def call(env)
           # look up image id
           image_id = @client
-            .request('/images')
+            .request('/v2/images')
             .find_id(:images, :name => @machine.provider_config.image)
 
           # submit rebuild request
-          result = @client.request("/droplets/#{@machine.id}/rebuild", {
-            :image_id => image_id
+          result = @client.post("/v2/droplets/#{@machine.id}/actions", {
+            :type => 'rebuild',
+            :image => image_id
           })
 
           # wait for request to complete
           env[:ui].info I18n.t('vagrant_digital_ocean.info.rebuilding')
-          @client.wait_for_event(env, result['event_id'])
+          @client.wait_for_event(env, result['action']['id'])
 
           # refresh droplet state with provider
           Provider.droplet(@machine, :refresh => true)

--- a/lib/vagrant-digitalocean/actions/reload.rb
+++ b/lib/vagrant-digitalocean/actions/reload.rb
@@ -15,11 +15,13 @@ module VagrantPlugins
 
         def call(env)
           # submit reboot droplet request
-          result = @client.request("/droplets/#{@machine.id}/reboot")
+          result = @client.post("/v2/droplets/#{@machine.id}/actions", {
+            :type => 'reboot'
+          })
 
           # wait for request to complete
           env[:ui].info I18n.t('vagrant_digital_ocean.info.reloading')
-          @client.wait_for_event(env, result['event_id'])
+          @client.wait_for_event(env, result['action']['id'])
 
           @app.call(env)
         end

--- a/lib/vagrant-digitalocean/actions/setup_key.rb
+++ b/lib/vagrant-digitalocean/actions/setup_key.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
           begin
             # assigns existing ssh key id to env for use by other commands
             env[:ssh_key_id] = @client
-              .request('/ssh_keys/')
+              .request('/v2/account/keys')
               .find_id(:ssh_keys, :name => ssh_key_name)
 
             env[:ui].info I18n.t('vagrant_digital_ocean.info.using_key', {
@@ -46,7 +46,7 @@ module VagrantPlugins
             :name => name
           }) 
 
-          result = @client.request('/ssh_keys/new', {
+          result = @client.post('/v2/account/keys', {
             :name => name,
             :ssh_pub_key => pub_key
           })

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -1,8 +1,7 @@
 module VagrantPlugins
   module DigitalOcean
     class Config < Vagrant.plugin('2', :config)
-      attr_accessor :client_id
-      attr_accessor :api_key
+      attr_accessor :token
       attr_accessor :image
       attr_accessor :region
       attr_accessor :size
@@ -15,8 +14,7 @@ module VagrantPlugins
       alias_method :setup?, :setup
 
       def initialize
-        @client_id          = UNSET_VALUE
-        @api_key            = UNSET_VALUE
+        @token              = UNSET_VALUE
         @image              = UNSET_VALUE
         @region             = UNSET_VALUE
         @size               = UNSET_VALUE
@@ -28,11 +26,10 @@ module VagrantPlugins
       end
 
       def finalize!
-        @client_id          = ENV['DO_CLIENT_ID'] if @client_id == UNSET_VALUE
-        @api_key            = ENV['DO_API_KEY'] if @api_key == UNSET_VALUE
+        @token              = ENV['DO_TOKEN'] if @token == UNSET_VALUE
         @image              = 'Ubuntu 14.04 x64' if @image == UNSET_VALUE
-        @region             = 'New York 2' if @region == UNSET_VALUE
-        @size               = '512MB' if @size == UNSET_VALUE
+        @region             = 'nyc2' if @region == UNSET_VALUE
+        @size               = '512mb' if @size == UNSET_VALUE
         @private_networking = false if @private_networking == UNSET_VALUE
         @backups_enabled    = false if @backups_enabled == UNSET_VALUE
         @ca_path            = nil if @ca_path == UNSET_VALUE
@@ -42,8 +39,7 @@ module VagrantPlugins
 
       def validate(machine)
         errors = []
-        errors << I18n.t('vagrant_digital_ocean.config.client_id') if !@client_id
-        errors << I18n.t('vagrant_digital_ocean.config.api_key') if !@api_key
+        errors << I18n.t('vagrant_digital_ocean.config.token') if !@token
 
         key = machine.config.ssh.private_key_path
         key = key[0] if key.is_a?(Array)

--- a/lib/vagrant-digitalocean/helpers/result.rb
+++ b/lib/vagrant-digitalocean/helpers/result.rb
@@ -10,14 +10,14 @@ module VagrantPlugins
           @result[key.to_s]
         end
 
-        def find_id(sub_obj, search)
+        def find_id(sub_obj, search) #:ssh_keys, {:name => 'ijin (vagrant)'}
           find(sub_obj, search)["id"]
         end
 
         def find(sub_obj, search)
-          key = search.keys.first
-          value = search[key].to_s
-          key = key.to_s
+          key = search.keys.first #:slug
+          value = search[key].to_s #sfo1
+          key = key.to_s #slug
 
           result = @result[sub_obj.to_s].inject(nil) do |result, obj|
             obj[key] == value ? obj : result

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -12,14 +12,14 @@ module VagrantPlugins
 
         # load status of droplets if it has not been done before
         if !@droplets
-          result = client.request('/droplets')
+          result = client.request('/v2/droplets')
           @droplets = result['droplets']
         end
 
         if opts[:refresh] && machine.id
           # refresh the droplet status for the given machine
           @droplets.delete_if { |d| d['id'].to_s == machine.id }
-          result = client.request("/droplets/#{machine.id}")
+          result = client.request("/v2/droplets/#{machine.id}")
           @droplets << droplet = result['droplet']
         else
           # lookup droplet status for the given machine
@@ -80,7 +80,7 @@ module VagrantPlugins
         return nil if droplet['status'].to_sym != :active
 
         return {
-          :host => droplet['ip_address'],
+          :host => droplet['networks']['v4'].first['ip_address'],
           :port => '22',
           :username => 'root',
           :private_key_path => nil

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -21,8 +21,7 @@ en:
       rsyncing: "Rsyncing folder: %{hostpath} => %{guestpath}..."
       rsync_missing: "The rsync executable was not found in the current path."
     config:
-      client_id: "Client ID is required"
-      api_key: "API key is required"
+      token: "Token is required"
       private_key: "SSH private key path is required"
       public_key: "SSH public key not found: %{key}"
     errors:

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -12,8 +12,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider :digital_ocean do |provider, override|
     override.vm.box = 'digital_ocean'
     override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
-    provider.client_id = ENV['DO_CLIENT_ID']
-    provider.api_key = ENV['DO_API_KEY']
+    provider.token = ENV['DO_TOKEN']
     provider.ssh_key_name = 'Test Key'
   end
 
@@ -26,7 +25,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :ubuntu do |ubuntu|
     ubuntu.vm.provider :digital_ocean do |provider|
-      provider.image = 'Ubuntu 12.04.4 x64'
+      provider.image = 'Ubuntu 14.04 x64'
     end
   end
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,14 +1,14 @@
-# if ! vagrant box list | grep digital_ocean 1>/dev/null; then
-#     vagrant box add digital_ocean box/digital_ocean.box
+# if ! bundle exec vagrant box list | grep digital_ocean 1>/dev/null; then
+#     bundle exec vagrant box add digital_ocean box/digital_ocean.box
 # fi
 
 cd test
 
-vagrant up --provider=digital_ocean
-vagrant up
-vagrant provision
-vagrant rebuild
-vagrant halt
-vagrant destroy
+bundle exec vagrant up --provider=digital_ocean
+bundle exec vagrant up
+bundle exec vagrant provision
+bundle exec vagrant rebuild
+bundle exec vagrant halt
+bundle exec vagrant destroy
 
 cd ..


### PR DESCRIPTION
Digital Ocean changed their API to v2.0
https://www.digitalocean.com/company/blog/api-v2-enters-public-beta/

This adds support for v2 and replaces the old v1 API.
(Old API keys are now hidden and not readily accessible anymore)
## Notable changes

To conform with the API documentation,
- provider.region uses slugs, such as `nyc2` instead of `New York 2`
- provider.size is now lowercase - `512mb`
