### PR TITLE
Using right field name for public ssh key in API v2.0

### DIFF
--- a/lib/vagrant-digitalocean/actions/setup_key.rb
+++ b/lib/vagrant-digitalocean/actions/setup_key.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
 
           result = @client.post('/v2/account/keys', {
             :name => name,
-            :ssh_pub_key => pub_key
+            :public_key => pub_key
           })
           result['ssh_key']['id']
         end


### PR DESCRIPTION
Public key field was updated according to https://developers.digitalocean.com/#keys
