### PR TITLE
v2.0 API pagination support

### DIFF
--- a/lib/vagrant-digitalocean/helpers/client.rb
+++ b/lib/vagrant-digitalocean/helpers/client.rb
@@ -57,6 +57,13 @@ module VagrantPlugins
             begin
               body = JSON.parse(result.body)
               @logger.info "Response: #{body}"
+              next_page = body["links"]["pages"]["next"] rescue nil
+              unless next_page.nil?
+                uri = URI.parse(next_page)
+                next_result = self.request("#{path}?#{uri.query}")
+                req_target = path.split("/")[-1]
+                body["#{req_target}"].concat(next_result["#{req_target}"])
+              end
             rescue JSON::ParserError => e
               raise(Errors::JSONError, {
                 :message => e.message,


### PR DESCRIPTION
Thanks for very nice plugin!!!

API v2.0 has new 'pagenation' feature.
https://developers.digitalocean.com/#links

> The links object is returned as part of the response body when pagination is enabled. By default, 25 objects are returned per page. If the response contains 25 objects or fewer, no links object will be returned. If the response contains more than 25 objects, the first 25 will be returned along with the links object.

This means, depends on the number of objects, additional API requests might be needed or "no such objects" error might happen.

ex) `provider.image = 'CentOS 7.0 x64'`

```
$ vagrant up --provider=digital_ocean
Bringing machine 'default' up with 'digital_ocean' provider...
==> default: Using existing SSH key: id_rsa
The result collection for images:

[{"id"=>1601, "name"=>"CentOS 5.8 x64", "distribution"=>"CentOS", "slug"=>"centos-5-8-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2012-04-09T11:17:11Z"}, {"id"=>1602, "name"=>"CentOS 5.8 x32", "distribution"=>"CentOS", "slug"=>"centos-5-8-x32", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2012-04-09T11:30:07Z"}, {"id"=>12573, "name"=>"Debian 6.0 x64", "distribution"=>"Debian", "slug"=>"debian-6-0-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2012-08-30T21:06:17Z"}, {"id"=>12575, "name"=>"Debian 6.0 x32", "distribution"=>"Debian", "slug"=>"debian-6-0-x32", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2012-08-30T22:51:48Z"}, {"id"=>14097, "name"=>"Ubuntu 10.04 x64", "distribution"=>"Ubuntu", "slug"=>"ubuntu-10-04-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2012-09-06T23:08:46Z"}, {"id"=>14098, "name"=>"Ubuntu 10.04 x32", "distribution"=>"Ubuntu", "slug"=>"ubuntu-10-04-x32", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2012-09-06T23:46:01Z"}, {"id"=>350424, "name"=>"Arch Linux 2013.05 x64", "distribution"=>"Arch Linux", "slug"=>"arch-linux-2013-05-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2013-05-21T15:10:19Z"}, {"id"=>361740, "name"=>"Arch Linux 2013.05 x32", "distribution"=>"Arch Linux", "slug"=>"arch-linux-2013-05-x32", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2013-05-23T19:09:50Z"}, {"id"=>376568, "name"=>"CentOS 6.4 x32", "distribution"=>"CentOS", "slug"=>"centos-6-4-x32", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2013-05-28T21:58:58Z"}, {"id"=>562354, "name"=>"CentOS 6.4 x64", "distribution"=>"CentOS", "slug"=>"centos-6-4-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2013-07-24T20:45:07Z"}, {"id"=>3100616, "name"=>"Ubuntu 12.04.4 x32", "distribution"=>"Ubuntu", "slug"=>"ubuntu-12-04-x32", "public"=>true, "regions"=>["nyc2", "ams1", "ams2", "nyc1", "sfo1", "sgp1", "lon1"], "created_at"=>"2014-04-09T18:57:23Z"}, {"id"=>3101045, "name"=>"Ubuntu 12.04.4 x64", "distribution"=>"Ubuntu", "slug"=>"ubuntu-12-04-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2014-04-09T19:31:25Z"}, {"id"=>3101580, "name"=>"Ubuntu 13.10 x32", "distribution"=>"Ubuntu", "slug"=>"ubuntu-13-10-x32", "public"=>true, "regions"=>["nyc2", "ams1", "nyc1", "sfo1", "sgp1", "ams2", "lon1"], "created_at"=>"2014-04-09T19:46:01Z"}, {"id"=>3101918, "name"=>"Ubuntu 13.10 x64", "distribution"=>"Ubuntu", "slug"=>"ubuntu-13-10-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2014-04-09T20:06:32Z"}, {"id"=>3102721, "name"=>"Fedora 19 x32", "distribution"=>"Fedora", "slug"=>"fedora-19-x32", "public"=>true, "regions"=>["nyc2", "ams1", "ams2", "sfo1", "nyc1", "sgp1", "lon1"], "created_at"=>"2014-04-09T20:56:56Z"}, {"id"=>3102879, "name"=>"Fedora 19 x64", "distribution"=>"Fedora", "slug"=>"fedora-19-x64", "public"=>true, "regions"=>["nyc2", "ams1", "ams2", "nyc1", "sfo1", "sgp1", "lon1"], "created_at"=>"2014-04-09T21:09:59Z"}, {"id"=>3121555, "name"=>"Ghost 0.4.2 on Ubuntu 12.04", "distribution"=>"Ubuntu", "slug"=>"ghost", "public"=>true, "regions"=>["nyc2", "ams1", "ams2", "nyc1", "sfo1", "sgp1", "lon1"], "created_at"=>"2014-04-10T21:43:46Z"}, {"id"=>3240033, "name"=>"Ubuntu 14.04 x32", "distribution"=>"Ubuntu", "slug"=>"ubuntu-14-04-x32", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2014-04-18T15:59:18Z"}, {"id"=>3240036, "name"=>"Ubuntu 14.04 x64", "distribution"=>"Ubuntu", "slug"=>"ubuntu-14-04-x64", "public"=>true, "regions"=>["nyc1", "ams1", "sfo1", "nyc2", "ams2", "sgp1", "lon1"], "created_at"=>"2014-04-18T15:59:36Z"}, {"id"=>3243143, "name"=>"Fedora 20 x32", "distribution"=>"Fedora", "slug"=>"fedora-20-x32", "public"=>true, "regions"=>["nyc2", "ams1", "ams2", "nyc1", "sfo1", "sgp1", "lon1"], "created_at"=>"2014-04-18T21:26:51Z"}]

Contained no object with the value "CentOS 7.0 x64" for the key "name".

Please ensure that the configured value exists in the collection.
```

ex) curl example

```
$ curl -X GET "https://api.digitalocean.com/v2/images/" -H "Authorization: Bearer $TOKEN"                 
{
  "images":[
    {
      "id":1601,
      "name":"CentOS 5.8 x64",
      "distribution":"CentOS",
      "slug":"centos-5-8-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2012-04-09T11:17:11Z"
    },
    {
      "id":1602,
      "name":"CentOS 5.8 x32",
      "distribution":"CentOS",
      "slug":"centos-5-8-x32",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2012-04-09T11:30:07Z"
    },
    {
      "id":12573,
      "name":"Debian 6.0 x64",
      "distribution":"Debian",
      "slug":"debian-6-0-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2012-08-30T21:06:17Z"
    },
    {
      "id":12575,
      "name":"Debian 6.0 x32",
      "distribution":"Debian",
      "slug":"debian-6-0-x32",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2012-08-30T22:51:48Z"
    },
    {
      "id":14097,
      "name":"Ubuntu 10.04 x64",
      "distribution":"Ubuntu",
      "slug":"ubuntu-10-04-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2012-09-06T23:08:46Z"
    },
    {
      "id":14098,
      "name":"Ubuntu 10.04 x32",
      "distribution":"Ubuntu",
      "slug":"ubuntu-10-04-x32",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2012-09-06T23:46:01Z"
    },
    {
      "id":350424,
      "name":"Arch Linux 2013.05 x64",
      "distribution":"Arch Linux",
      "slug":"arch-linux-2013-05-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2013-05-21T15:10:19Z"
    },
    {
      "id":361740,
      "name":"Arch Linux 2013.05 x32",
      "distribution":"Arch Linux",
      "slug":"arch-linux-2013-05-x32",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2013-05-23T19:09:50Z"
    },
    {
      "id":376568,
      "name":"CentOS 6.4 x32",
      "distribution":"CentOS",
      "slug":"centos-6-4-x32",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2013-05-28T21:58:58Z"
    },
    {
      "id":562354,
      "name":"CentOS 6.4 x64",
      "distribution":"CentOS",
      "slug":"centos-6-4-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2013-07-24T20:45:07Z"
    },
    {
      "id":3100616,
      "name":"Ubuntu 12.04.4 x32",
      "distribution":"Ubuntu",
      "slug":"ubuntu-12-04-x32",
      "public":true,
      "regions":[
        "nyc2",
        "ams1",
        "ams2",
        "nyc1",
        "sfo1",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-09T18:57:23Z"
    },
    {
      "id":3101045,
      "name":"Ubuntu 12.04.4 x64",
      "distribution":"Ubuntu",
      "slug":"ubuntu-12-04-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-09T19:31:25Z"
    },
    {
      "id":3101580,
      "name":"Ubuntu 13.10 x32",
      "distribution":"Ubuntu",
      "slug":"ubuntu-13-10-x32",
      "public":true,
      "regions":[
        "nyc2",
        "ams1",
        "nyc1",
        "sfo1",
        "sgp1",
        "ams2",
        "lon1"
      ],
      "created_at":"2014-04-09T19:46:01Z"
    },
    {
      "id":3101918,
      "name":"Ubuntu 13.10 x64",
      "distribution":"Ubuntu",
      "slug":"ubuntu-13-10-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-09T20:06:32Z"
    },
    {
      "id":3102721,
      "name":"Fedora 19 x32",
      "distribution":"Fedora",
      "slug":"fedora-19-x32",
      "public":true,
      "regions":[
        "nyc2",
        "ams1",
        "ams2",
        "sfo1",
        "nyc1",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-09T20:56:56Z"
    },
    {
      "id":3102879,
      "name":"Fedora 19 x64",
      "distribution":"Fedora",
      "slug":"fedora-19-x64",
      "public":true,
      "regions":[
        "nyc2",
        "ams1",
        "ams2",
        "nyc1",
        "sfo1",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-09T21:09:59Z"
    },
    {
      "id":3121555,
      "name":"Ghost 0.4.2 on Ubuntu 12.04",
      "distribution":"Ubuntu",
      "slug":"ghost",
      "public":true,
      "regions":[
        "nyc2",
        "ams1",
        "ams2",
        "nyc1",
        "sfo1",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-10T21:43:46Z"
    },
    {
      "id":3240033,
      "name":"Ubuntu 14.04 x32",
      "distribution":"Ubuntu",
      "slug":"ubuntu-14-04-x32",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-18T15:59:18Z"
    },
    {
      "id":3240036,
      "name":"Ubuntu 14.04 x64",
      "distribution":"Ubuntu",
      "slug":"ubuntu-14-04-x64",
      "public":true,
      "regions":[
        "nyc1",
        "ams1",
        "sfo1",
        "nyc2",
        "ams2",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-18T15:59:36Z"
    },
    {
      "id":3243143,
      "name":"Fedora 20 x32",
      "distribution":"Fedora",
      "slug":"fedora-20-x32",
      "public":true,
      "regions":[
        "nyc2",
        "ams1",
        "ams2",
        "nyc1",
        "sfo1",
        "sgp1",
        "lon1"
      ],
      "created_at":"2014-04-18T21:26:51Z"
    }
  ],
  "meta":{
    "total":37
  },
  "links":{
    "pages":{
      "last":"https://api.digitalocean.com/v2/images/?page=2",
      "next":"https://api.digitalocean.com/v2/images/?page=2"
    }
  }
}
```

`rake test`, which adds "CentOS 7.0 x64" VM, passed.
