### PR TITLE
fix v2 api typo on auto backup feature when create droplet

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
             :name => @machine.config.vm.hostname || @machine.name,
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,
-            :backups_enabled => @machine.provider_config.backups_enabled
+            :backups => @machine.provider_config.backups_enabled
           })
 
           # wait for request to complete


### PR DESCRIPTION
Hi, I found out that there's a typo when creating droplet with backup enable feature
For v1, the API is key is 'backups_enabled', but in v2, the API is change to 'backups'

please let me know if you want to rename provider_config API from backups_enabled to backups.
