### PR TITLE
Further update Gemfile groups for Vagrant v1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.6.3'
-gem 'vagrant-omnibus'
-gem 'rake'
-
-group :plugins do
-  gem 'vagrant-digitalocean', :path => '.'
+group :development do
+  gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git'
+  gem 'rake'
 end
 
-gemspec
+group :plugins do
+  gemspec
+  gem 'vagrant-omnibus'
+end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,6 +1,3 @@
-Vagrant.require_plugin('vagrant-digitalocean')
-Vagrant.require_plugin('vagrant-omnibus')
-
 Vagrant.configure('2') do |config|
   config.omnibus.chef_version = :latest
 


### PR DESCRIPTION
Expands on 7815ee7, preventing errors and warnings on the `bundle exec rake test` (e.g., `Unknown configuration section 'omnibus'` and `Your Gemfile lists the gem vagrant-digitalocean (>= 0) more than once`).

Vagrant's [v1.5 blog post](https://www.vagrantup.com/blog/vagrant-1-5-plugin-improvements.html#toc_1) suggests that gone are the days when "plugin developers had to create Vagrantfiles that manually did a require of all plugins they needed" (also in [documentation](https://docs.vagrantup.com/v2/plugins/packaging.html)). 

However, the vagrant-aws plugin (that the vagrant docs so often cite as _the_ model) currently still uses the old method of requiring vagrant-aws at top of Vagrantfile, leaving [some](https://github.com/mitchellh/vagrant-aws/pull/246#issuecomment-50064189) asking "What's the proper way to load our local fork in the Vagrant bundler environment?"

I don't understand it all but went with what appears to be the more up-to-date approach. [Vagrant-parallels](https://github.com/Parallels/vagrant-parallels/blob/307b69b1d2e0d195315b85a1563180430277a66a/Gemfile) is one of the few [provider plugins](https://github.com/mitchellh/vagrant/wiki/Available-Vagrant-Plugins#providers) to do the same. I'm guessing the others just haven't gotten around to it.
