### PR TITLE
Add user data as a provider param

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -30,7 +30,8 @@ module VagrantPlugins
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,
             :backups => @machine.provider_config.backups_enabled,
-            :ipv6 => @machine.provider_config.ipv6
+            :ipv6 => @machine.provider_config.ipv6,
+            :user_data => @machine.provider_config.user_data
           })
 
           # wait for request to complete

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :ca_path
       attr_accessor :ssh_key_name
       attr_accessor :setup
+      attr_accessor :user_data
 
       alias_method :setup?, :setup
 
@@ -25,6 +26,7 @@ module VagrantPlugins
         @ca_path            = UNSET_VALUE
         @ssh_key_name       = UNSET_VALUE
         @setup              = UNSET_VALUE
+        @user_data          = UNSET_VALUE
       end
 
       def finalize!
@@ -38,6 +40,7 @@ module VagrantPlugins
         @ca_path            = nil if @ca_path == UNSET_VALUE
         @ssh_key_name       = 'Vagrant' if @ssh_key_name == UNSET_VALUE
         @setup              = true if @setup == UNSET_VALUE
+        @user_data          = nil if @user_data == UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
With the introduction of CoreOS on digitalocean, I was trying to fire up a cluster with the plugin but it was a pain because the best way to that, which is by setting cloud-init data in the droplet to be picked at boot, was impossible using vagrant-digitalocean.

So I added it, and here it is

Thanks for a great gem
