### PR TITLE
Mark provider as non-defaultable

### DIFF
--- a/lib/vagrant-digitalocean/plugin.rb
+++ b/lib/vagrant-digitalocean/plugin.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:digital_ocean, parallel: true) do
+      provider(:digital_ocean, parallel: true, defaultable: false) do
         require_relative 'provider'
         Provider
       end


### PR DESCRIPTION
Since creating a DigitalOcean droplet requires a token to be specified in the `Vagrantfile`, this provider will not work out-of-the-box with any arbitrary `Vagrantfile`. This is a problem for users who have DigitalOcean first in their provider list (e.g. by having none of the default providers' backends installed) and a working provider later in the list. DigitalOcean will return an "unauthorized" response and prevent Vagrant from trying later providers, forcing the user to manually specify their desired provider.

Additionally, as droplets begin to incur a fee as soon as they're created, defaulting to the DigitalOcean provider for `Vagrantfile`s that make no mention of it might cause users to receive an unintentional bill—for example, in the case where they've specified their DigitalOcean token in a user- or system-wide `Vagrantfile`.

This commit has no effect on the current behavior in cases where
 - a `Vagrantfile` contains a `config.vm.provider :digital_ocean` section
 - a user passes a provider explicitly on the command line
 - the `VAGRANT_DEFAULT_PROVIDER` environment variable is set