### PR TITLE
Fix name bug where fallback is always 'default'

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             :size => @machine.provider_config.size,
             :region => @machine.provider_config.region,
             :image => @machine.provider_config.image,
-            :name => @machine.config.vm.hostname || @machine.name,
+            :name => @machine.config.vm.hostname || @machine.provider_config.name || @machine.name,
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,
             :backups => @machine.provider_config.backups_enabled,

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
       attr_accessor :ssh_key_name
       attr_accessor :setup
       attr_accessor :user_data
+      attr_accessor :name
 
       alias_method :setup?, :setup
 
@@ -27,6 +28,7 @@ module VagrantPlugins
         @ssh_key_name       = UNSET_VALUE
         @setup              = UNSET_VALUE
         @user_data          = UNSET_VALUE
+        @name               = UNSET_VALUE
       end
 
       def finalize!
@@ -41,6 +43,7 @@ module VagrantPlugins
         @ssh_key_name       = 'Vagrant' if @ssh_key_name == UNSET_VALUE
         @setup              = true if @setup == UNSET_VALUE
         @user_data          = nil if @user_data == UNSET_VALUE
+        @name               = nil if @name == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
         # and set the id to ensure vagrant stores locally
         # TODO allow the user to configure this behavior
         if !droplet
-          name = machine.config.vm.hostname || machine.name
+          name = machine.config.vm.hostname || machine.provider_config.name || machine.name
           droplet = @droplets.find { |d| d['name'] == name.to_s }
           machine.id = droplet['id'].to_s if droplet
         end


### PR DESCRIPTION
As noted in #196 and #246, the fallback droplet name is always `default` instead of the value of `provider.name`. I'm not sure if this was working correctly in an earlier version of this plugin, but I believe it is unanimous that it isn't working currently. My proposed fix introduces an intermediary value that actually calls from `machine.provider_config.name` which pulls the value from the specified `provider.name` in the Vagrantfile. If both `config.vm.hostname` and `provider.name` aren't specified, then it will fallback to the previous `default` value from `machine.name`.