### PR TITLE
Change precedence of droplet name config values

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             :size => @machine.provider_config.size,
             :region => @machine.provider_config.region,
             :image => @machine.provider_config.image,
-            :name => @machine.config.vm.hostname || @machine.provider_config.name || @machine.name,
+            :name => @machine.provider_config.name || @machine.config.vm.hostname || @machine.name,
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,
             :backups => @machine.provider_config.backups_enabled,

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             :size => @machine.provider_config.size,
             :region => @machine.provider_config.region,
             :image => @machine.provider_config.image,
-            :name => @machine.config.vm.hostname || @machine.name,
+            :name => @machine.config.vm.hostname || @machine.provider_config.name || @machine.name,
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,
             :backups => @machine.provider_config.backups_enabled,

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
       attr_accessor :ssh_key_name
       attr_accessor :setup
       attr_accessor :user_data
+      attr_accessor :name
 
       alias_method :setup?, :setup
 
@@ -27,6 +28,7 @@ module VagrantPlugins
         @ssh_key_name       = UNSET_VALUE
         @setup              = UNSET_VALUE
         @user_data          = UNSET_VALUE
+        @name               = UNSET_VALUE
       end
 
       def finalize!
@@ -41,6 +43,7 @@ module VagrantPlugins
         @ssh_key_name       = 'Vagrant' if @ssh_key_name == UNSET_VALUE
         @setup              = true if @setup == UNSET_VALUE
         @user_data          = nil if @user_data == UNSET_VALUE
+        @name               = nil if @name == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
         # and set the id to ensure vagrant stores locally
         # TODO allow the user to configure this behavior
         if !droplet
-          name = machine.config.vm.hostname || machine.provider_config.name || machine.name
+          name = machine.provider_config.name || machine.config.vm.hostname || machine.name
           droplet = @droplets.find { |d| d['name'] == name.to_s }
           machine.id = droplet['id'].to_s if droplet
         end

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
         # and set the id to ensure vagrant stores locally
         # TODO allow the user to configure this behavior
         if !droplet
-          name = machine.config.vm.hostname || machine.name
+          name = machine.config.vm.hostname || machine.provider_config.name || machine.name
           droplet = @droplets.find { |d| d['name'] == name.to_s }
           machine.id = droplet['id'].to_s if droplet
         end


### PR DESCRIPTION
This PR actually requires that PR #247 gets merged in as well, but if it does, this PR will fix issue #234. It seems that `config.vm.hostname` overrides `provider.name`, and I don't believe this is the intended functionality. By allowing users to override `config.vm.hostname` with the optional `provider.name` to set the droplet name, we would be allowing the plugin to be more configurable by the user. There are instances where the `config.vm.hostname` and `provider.name` options could be different values, and this new order would allow each to still function properly.