### PR TITLE
Fix bug with provider default behavior in latest versions of vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Vagrant.configure('2') do |config|
         override.ssh.private_key_path = '~/.ssh/id_rsa'
         override.vm.box = 'digital_ocean'
         override.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+        override.nfs.functional = false
         provider.token = 'YOUR TOKEN'
         provider.image = 'ubuntu-14-04-x64'
         provider.region = 'nyc1'


### PR DESCRIPTION
## Purpose:
- Fix bug with provider default behavior in latest versions of vagrant

## Bug:
- Run `vagrant up --provider=digital_ocean` with the latest versions of vagrant
- Notice:
```
ERROR loader: Unknown config sources: [:"2153928420_vm_droplet1__digital_ocean"]
Bringing machine 'droplet1' up with 'digital_ocean' provider...
==> droplet1: Using existing SSH key: Vagrant
==> droplet1: Creating a new droplet...
==> droplet1: Assigned IP address: 67.205.183.231
ERROR warden: Error occurred: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
ERROR warden: Error occurred: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
ERROR warden: Error occurred: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
ERROR warden: Error occurred: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
ERROR warden: Error occurred: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
ERROR vagrant: Vagrant experienced an error! Details:
ERROR vagrant: #<Vagrant::Errors::NFSNoHostIP: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.>
ERROR vagrant: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
ERROR vagrant: /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/plugins/synced_folders/nfs/synced_folder.rb:43:in `enable'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/synced_folders.rb:93:in `block in call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/synced_folders.rb:90:in `each'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/synced_folders.rb:90:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-digitalocean-0.9.1/lib/vagrant-digitalocean/actions/modify_provision_path.rb:33:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-cachier-1.2.1/lib/vagrant-cachier/action/install_buckets.rb:14:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/provision.rb:80:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-cachier-1.2.1/lib/vagrant-cachier/action/configure_bucket_root.rb:20:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builder.rb:116:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:66:in `block in run'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/util/busy.rb:19:in `busy'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:66:in `run'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/call.rb:53:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-digitalocean-0.9.1/lib/vagrant-digitalocean/actions/setup_user.rb:16:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-digitalocean-0.9.1/lib/vagrant-digitalocean/actions/setup_sudo.rb:43:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-digitalocean-0.9.1/lib/vagrant-digitalocean/actions/create.rb:65:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/Users/developer/.vagrant.d/gems/gems/vagrant-digitalocean-0.9.1/lib/vagrant-digitalocean/actions/setup_key.rb:33:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builder.rb:116:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:66:in `block in run'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/util/busy.rb:19:in `busy'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:66:in `run'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/call.rb:53:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/builder.rb:116:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:66:in `block in run'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/util/busy.rb:19:in `busy'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:66:in `run'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/machine.rb:225:in `action_raw'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/machine.rb:200:in `block in action'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:567:in `lock'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/machine.rb:186:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/machine.rb:186:in `action'
/opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.
```

## Resources to fix it:
- Vagrant GitHub Issue: https://github.com/mitchellh/vagrant/issues/5401

## Notes:
- This changes the default behavior from NFS to rsync