### PR TITLE
Update client to send JSON in the body

### DIFF
--- a/lib/vagrant-digitalocean/helpers/client.rb
+++ b/lib/vagrant-digitalocean/helpers/client.rb
@@ -39,7 +39,8 @@ module VagrantPlugins
           begin
             @logger.info "Request: #{path}"
             result = @client.send(method) do |req|
-              req.url path, params
+              req.url path
+              req.body = params.to_json
               req.headers['Authorization'] = "Bearer #{@config.token}"
             end
           rescue Faraday::Error::ConnectionFailed => e


### PR DESCRIPTION
DigitalOcean's API no longer accepts sending the params in the URL. They must be in the body. This commit makes that change. 

Tested against Vagrant 2.2.7 and the current DigitalOcean API as of 3/10/2020.