### PR TITLE
Relates to #298: Fix for ruby 3.x named parameter syntax changes.

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -44,13 +44,9 @@ module VagrantPlugins
           droplet = Provider.droplet(@machine, :refresh => true)
           public_network = droplet['networks']['v4'].find { |network| network['type'] == 'public' }
           private_network = droplet['networks']['v4'].find { |network| network['type'] == 'private' }
-          env[:ui].info I18n.t('vagrant_digital_ocean.info.droplet_ip', {
-            :ip => public_network['ip_address']
-          })
+          env[:ui].info I18n.t('vagrant_digital_ocean.info.droplet_ip', :ip => public_network['ip_address'])
           if private_network
-            env[:ui].info I18n.t('vagrant_digital_ocean.info.droplet_private_ip', {
-              :ip => private_network['ip_address']
-            })
+            env[:ui].info I18n.t('vagrant_digital_ocean.info.droplet_private_ip', :ip => private_network['ip_address'])
           end
 
           # wait for ssh to be ready

--- a/lib/vagrant-digitalocean/actions/setup_key.rb
+++ b/lib/vagrant-digitalocean/actions/setup_key.rb
@@ -23,9 +23,7 @@ module VagrantPlugins
               .request('/v2/account/keys')
               .find_id(:ssh_keys, :name => ssh_key_name)
 
-            env[:ui].info I18n.t('vagrant_digital_ocean.info.using_key', {
-              :name => ssh_key_name
-            })
+            env[:ui].info I18n.t('vagrant_digital_ocean.info.using_key', :name => ssh_key_name)
           rescue Errors::ResultMatchError
             env[:ssh_key_id] = create_ssh_key(ssh_key_name, env)
           end
@@ -42,9 +40,7 @@ module VagrantPlugins
           path = File.expand_path(path, @machine.env.root_path)
           pub_key = DigitalOcean.public_key(path)
 
-          env[:ui].info I18n.t('vagrant_digital_ocean.info.creating_key', {
-            :name => name
-          }) 
+          env[:ui].info I18n.t('vagrant_digital_ocean.info.creating_key', :name => name)
 
           result = @client.post('/v2/account/keys', {
             :name => name,

--- a/lib/vagrant-digitalocean/actions/setup_user.rb
+++ b/lib/vagrant-digitalocean/actions/setup_user.rb
@@ -19,9 +19,7 @@ module VagrantPlugins
           user = @machine.config.ssh.username
           @machine.config.ssh.username = 'root'
 
-          env[:ui].info I18n.t('vagrant_digital_ocean.info.creating_user', {
-            :user => user
-          })
+          env[:ui].info I18n.t('vagrant_digital_ocean.info.creating_user', :user => user)
 
           # create user account
           @machine.communicate.execute(<<-BASH)


### PR DESCRIPTION
I've found all the incidences of the old named parameter syntax and updated them.

I've tested my fix (and others can run it, too, until there's a new release) using the "Testing" instructions under the [contribute](https://github.com/devopsgroup-io/vagrant-digitalocean#contribute) section of the docs.

This works for [my Vagrant use case](https://gitlab.com/lamech/vagrant-remote-dev); I am able to `vagrant up` and get what I expect (see the README there), and `vagrant destroy` to throw it away, without encountering the error in #298.

Hope this helps!